### PR TITLE
Add Hidden Tech links

### DIFF
--- a/resources.md
+++ b/resources.md
@@ -63,7 +63,7 @@ This file contains links to local tech-related resources.
 - [Western Mass tech job listings](job-listings.md)
 - [Jobs in the Valley](http://jobsinthevalley.com/)
 - [Built in Boston](https://www.builtinboston.com) - Boston tech companies, with information on remote-friendly orgs
-- [Hidden Tech](http://www.westernmassedc.com/boston_area_industrial_clusters/hiddentech/) - this is a [mailing list](#groups--email-lists), but people frequently use it to post job openings
+- [Hidden Tech](http://www.hidden-tech.net/) - this is a [mailing list](#groups--email-lists), but people frequently use it to post job openings
 
 ### Local funding resources / incubators
 
@@ -82,7 +82,7 @@ This file contains links to local tech-related resources.
 
 ### Groups / email lists
 
-- [Hidden Tech](http://www.westernmassedc.com/boston_area_industrial_clusters/hiddentech/) - **Registration page currently unavailable**
+- [Hidden Tech](http://www.hidden-tech.net/join/)
 - [NERD Slack](https://nerdslack.herokuapp.com/) - Slack for New England Regional Developers
 
 ### Other resource lists


### PR DESCRIPTION
The Hidden Tech links were outdated and they once again have their mailing list join link live - added those.